### PR TITLE
🐛 Bug fixed: link does not go to GitHub

### DIFF
--- a/src/Comp/Navbar.js
+++ b/src/Comp/Navbar.js
@@ -78,11 +78,7 @@ function Navbar(props) {
            </Tooltip>
            {check &&
            <Tooltip label="Star! on github" >
-             <Link to={{pathname:'https://github.com/tewarig/torii/'}} targe="_blank">
-
- 
-           <IconButton ml={2} mr={1} icon={<FaGithub/>}  isRound="true"></IconButton>
-           </Link>
+            <a href='https://github.com/tewarig/torii/' target='_blank'><IconButton ml={2} mr={1} icon={<FaGithub/>}  isRound="true"></IconButton></a>           
            </Tooltip>
            }
            { check &&


### PR DESCRIPTION
The `<Link>` component causes it to go to `https://toriii.vercel.app/https://github.com/tewarig/torii`.
I fixed it by replacing the Link component with an `<a>` tag